### PR TITLE
Change preferences defined in plugin.xml.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
     <license>MIT</license>
     
     <engines>
-        <engine name="cordova" version=">=3.5.0"/>
+        <engine name="cordova" version=">=4.0.0"/>
         <!-- When multiple SDKs are installed the check will fail, seems to be a bug in cordova-lib -->
         <!--<engine name="apple-ios" version=">=8.2.0"/>-->
     </engines>
@@ -30,7 +30,7 @@
                 <param name="ios-package" value="AppleWatch"/>
                 <param name="onload" value="true"/>
             </feature>
-            <preference name="deployment-target" value="9.0"/>
+            <preference name="deployment-target" value="8.2"/>
         </config-file>
         
         <header-file src="src/ios/app/AppleWatch.h"/>


### PR DESCRIPTION
<b>Description</b>: 
- Revert minimum deployment target preference from 9.0 to 8.2.
- Change minimum cordova engine version from `3.5.0` to `4.0.0`. This is necessary only for `AppBuilder` servers because builds for cordova engine version less than `4.0.0` use Xcode 6.4 which does not have installed the `watchOS` SDK.
