### PR TITLE
[AppBuilder][iOS]Set 'SKIP_INSTALL' to YES.

### DIFF
--- a/src/ios/hooks/ab/watchkit-app.js
+++ b/src/ios/hooks/ab/watchkit-app.js
@@ -19,7 +19,7 @@ function addWatchkitAppTarget(pbxProject, prop) {
             IPHONEOS_DEPLOYMENT_TARGET: 8.2, //Hardcoding this - problems may arise
             PRODUCT_NAME: '"${TARGET_NAME}"',
 			PROVISIONING_PROFILE: '"${PROVISION_WATCHKITAPP}"',
-            SKIP_INSTALL: 'NO',
+            SKIP_INSTALL: 'YES',
             TARGETED_DEVICE_FAMILY: 4, //Hardcoding this also
             '"TARGETED_DEVICE_FAMILY[sdk=iphonesimulator*]"': '"1,4"', // According to apple documentation 1 is for iPhone/iPad and 2 is for iPad - I'm guessing 4 is for AppleWatch
             COPY_PHASE_STRIP: 'NO',
@@ -35,7 +35,7 @@ function addWatchkitAppTarget(pbxProject, prop) {
                 IPHONEOS_DEPLOYMENT_TARGET: 8.2, //Hardcoding this - problems may arise
                 PRODUCT_NAME: '"${TARGET_NAME}"',
 				PROVISIONING_PROFILE: '"${PROVISION_WATCHKITAPP}"',
-                SKIP_INSTALL: 'NO',
+                SKIP_INSTALL: 'YES',
                 TARGETED_DEVICE_FAMILY: 4, //Hardcoding this also
                 '"TARGETED_DEVICE_FAMILY[sdk=iphonesimulator*]"': '"1,4"', // According to apple documentation 1 is for iPhone/iPad and 2 is for iPad - I'm guessing 4 is for AppleWatch
                 COPY_PHASE_STRIP: 'NO'


### PR DESCRIPTION
AppBuilder's build tooling will be using the depricated method for
exporting `.xcarchive`'s to `.ipa`. When using the command below
exports fail.

`'xcrun xcodebuild -exportArchive -archivePath <path-to-xcarchive>
-exportPath <path-to-ipa-product> -exportFormat ipa'`

The error message is 

> error: the archive at path '<path>.xcarchive' is not a single-bundle archive
> *\* EXPORT FAILED **

Currently, the tooling can't be easily migrated to use the new -exportOptionsPlist,
so after addtional investigation, it turned out that the issue occures for main
target dependencies which have the setting `SKIP_INSTALL = 'NO'`. Once changed to `'YES'`,
the export succeeds.

Related PRs:
- https://github.com/Icenium/BpcTooling/pull/562
